### PR TITLE
GPII-2354: dxdiag fails on Win7x64

### DIFF
--- a/System_Information.bat
+++ b/System_Information.bat
@@ -11,7 +11,7 @@ SET filePath="System Information\System_Information.txt"
 :: Run Dxdiag
 echo Collecting hardware information
 echo ------- Hardware Information --------- > %filePath%
-dxdiag /T dxdiag.txt
+dxdiag /64bit /T dxdiag.txt
 type dxdiag.txt >> %filePath%
 del dxdiag.txt
 


### PR DESCRIPTION
Added /64bit option to dxdiag to stop it spawning another process on Win7x64 and exiting early.
